### PR TITLE
Schließe fpin nur, wenn es definiert wurde

### DIFF
--- a/files/usr/local/bin/mtv_cli.py
+++ b/files/usr/local/bin/mtv_cli.py
@@ -41,7 +41,7 @@ def get_url_fp(url):
 # --- Stream des LZMA-Entpackers   ------------------------------------------
 
 def get_lzma_fp(url_fp):
-  """ Fileponter des LZMA-Entpackers. Argument ist der FP der URL"""
+  """ Filepointer des LZMA-Entpackers. Argument ist der FP der URL"""
   return lzma.open(url_fp,"rt",encoding='utf-8')
 
 # --- Split der Datei   -----------------------------------------------------
@@ -222,7 +222,7 @@ def do_now(options):
     changes = save_selected(options.filmDB,rows,selected,"S")
     Msg.msg("INFO","%d von %d Filme vorgemerkt für Sofort-Download" % (changes,len(selected)))
 
-    # Anstoß Downlaod
+    # Anstoß Download
     if changes > 0:
       do_download(options)
   else:

--- a/files/usr/local/bin/mtv_cli.py
+++ b/files/usr/local/bin/mtv_cli.py
@@ -48,7 +48,7 @@ def get_lzma_fp(url_fp):
 
 def split_content(fpin,filmDB):
   """Inhalt aufteilen"""
-  
+
   have_header=False
   last_rec = ""
 
@@ -77,7 +77,7 @@ def split_content(fpin,filmDB):
     records = regex.split(last_rec+str(buffer))
     Msg.msg("DEBUG","Anzahl Sätze: %d" % len(records))
 
-    # Sätze ausgeben. Der letzte Satz ist entweder leer, 
+    # Sätze ausgeben. Der letzte Satz ist entweder leer,
     # oder er ist eigentlich ein Satzanfang und wird aufgehoben
     last_rec = records[-1]
     for record in records[0:-1]:
@@ -97,7 +97,7 @@ def split_content(fpin,filmDB):
   Msg.msg("INFO","Anzahl Sätze (gesamt):      %d" % total)
   Msg.msg("INFO","Anzahl Sätze (gespeichert): %d" % filmDB.get_count())
 
-    
+
 # --- Update verarbeiten   --------------------------------------------------
 
 def do_update(options):
@@ -193,7 +193,7 @@ def save_selected(filmDB,rows,selected,status):
     row = rows[sel_index]
     inserts.append((row['_ID'],row['DATUM'],status))
   return filmDB.save_downloads(inserts)
-  
+
 # --- Filmliste anzeigen, Auswahl für späteren Download speichern    --------
 
 def do_later(options):
@@ -319,7 +319,7 @@ def get_parser():
   parser.add_argument('-E', '--edit', action='store_true',
     dest='doEdit',
     help='Downloadliste bearbeiten')
-  
+
   parser.add_argument('-D', '--download', action='store_true',
     dest='doDownload',
     help='Vorgemerkte Filme herunterladen')

--- a/files/usr/local/bin/mtv_cli.py
+++ b/files/usr/local/bin/mtv_cli.py
@@ -121,7 +121,8 @@ def do_update(options):
   except Exception as e:
     Msg.msg("ERROR","Update der Filmliste gescheitert. Fehler: %s" % e)
   finally:
-    fpin.close()
+    if "fpin" in vars():
+      fpin.close()
 
 # --- Interaktiv Suchbegriffe festlegen   -----------------------------------
 

--- a/files/usr/local/bin/mtv_const.py
+++ b/files/usr/local/bin/mtv_const.py
@@ -33,12 +33,6 @@ MTV_CLI_SQLITE=os.path.join(MTV_CLI_HOME,"mtv_cli.sqlite")
 
 # --- Download-URLs   --------------------------------------------------------
 
-URL_FILMLISTE=[
-  "http://verteiler4.mediathekview.de/Filmliste-akt.xz",
-  "http://verteiler5.mediathekview.de/Filmliste-akt.xz",
-  "http://verteiler6.mediathekview.de/Filmliste-akt.xz",
-  "http://verteiler1.mediathekview.de/Filmliste-akt.xz",
-  "http://verteiler2.mediathekview.de/Filmliste-akt.xz",
-  "http://verteiler3.mediathekview.de/Filmliste-akt.xz"
-  ]
-
+URL_FILMLISTE = [
+    "https://liste.mediathekview.de/Filmliste-akt.xz",
+]

--- a/files/usr/local/bin/mtv_const.py
+++ b/files/usr/local/bin/mtv_const.py
@@ -31,7 +31,7 @@ MTV_CLI_HOME=os.path.join(os.path.expanduser("~"),".mediathek3")
 FILME_SQLITE=os.path.join(MTV_CLI_HOME,"filme.sqlite")
 MTV_CLI_SQLITE=os.path.join(MTV_CLI_HOME,"mtv_cli.sqlite")
 
-# --- Downlaod-URLs   --------------------------------------------------------
+# --- Download-URLs   --------------------------------------------------------
 
 URL_FILMLISTE=[
   "http://verteiler4.mediathekview.de/Filmliste-akt.xz",

--- a/files/usr/local/bin/mtv_download.py
+++ b/files/usr/local/bin/mtv_download.py
@@ -3,7 +3,7 @@
 # --------------------------------------------------------------------------
 # Mediathekview auf der Kommandozeile
 #
-# Methoden rund um den Downlaod
+# Methoden rund um den Download
 #
 # Author: Bernhard Bablok
 # License: GPL3

--- a/files/usr/local/bin/mtv_filmdb.py
+++ b/files/usr/local/bin/mtv_filmdb.py
@@ -3,7 +3,7 @@
 # --------------------------------------------------------------------------
 # Mediathekview auf der Kommandozeile
 #
-# Class FilmDB, MtvDB: Alles rund im Datenbanken
+# Class FilmDB, MtvDB: Alles rund um Datenbanken
 #
 # Author: Bernhard Bablok
 # License: GPL3

--- a/files/usr/local/bin/mtv_filmdb.py
+++ b/files/usr/local/bin/mtv_filmdb.py
@@ -25,7 +25,7 @@ class FilmDB(object):
   """Datenbank aller Filme"""
 
   # ------------------------------------------------------------------------
-  
+
   def __init__(self,options):
     """Constructor"""
     self.config = options.config
@@ -136,19 +136,19 @@ class FilmDB(object):
     if film_info:
       self.total += 1
       self.cursor.execute(INSERT_STMT,film_info.asTuple())
-  
+
   # ------------------------------------------------------------------------
 
   def commit(self):
     """Commit durchführen"""
     self.db.commit()
-    
+
   # ------------------------------------------------------------------------
 
   def get_count(self):
     """Anzahl der schon eingefügten Sätze zurückgeben"""
     return self.total
-  
+
   # ------------------------------------------------------------------------
 
   def save_filmtable(self):
@@ -170,7 +170,7 @@ class FilmDB(object):
            parts[2] + "-" + parts[1] + "-" + parts[0]
 
   # ------------------------------------------------------------------------
-  
+
   def get_query(self,suche):
     """Aus Suchbegriff eine SQL-Query erzeugen"""
     #Basisausdruck
@@ -236,7 +236,7 @@ class FilmDB(object):
     return select_clause + where_clause
 
   # ------------------------------------------------------------------------
-  
+
   def execute_query(self,statement):
     """Suche ausführen"""
     cursor = self.open()

--- a/files/usr/local/bin/mtv_filminfo.py
+++ b/files/usr/local/bin/mtv_filminfo.py
@@ -18,7 +18,7 @@ class FilmInfo(object):
   """Info über einen einzelnen Film"""
 
     # ------------------------------------------------------------------------
-  
+
   def __init__(self,sender,thema,titel,datum,zeit,dauer,
                groesse,beschreibung,url,website,url_untertitel,url_rtmp,
                url_klein,url_rtmp_klein,url_hd,url_rtmp_hd,datumL,

--- a/files/usr/local/bin/mtv_msg.py
+++ b/files/usr/local/bin/mtv_msg.py
@@ -28,7 +28,7 @@ class Msg(object):
   level = "INFO"    # beim Initialisieren überschreiben
 
   # --- Ausgabe einer Meldung   ---------------------------------------------
-  
+
   def msg(msg_level,text,nl=True):
     """Ausgabe einer Meldung"""
     if Msg.MSG_LEVELS[msg_level] >= Msg.MSG_LEVELS[Msg.level]:

--- a/files/usr/local/bin/mtv_web.py
+++ b/files/usr/local/bin/mtv_web.py
@@ -50,7 +50,7 @@ def get_webpath(path):
 def css_pages(filepath):
     print(filepath)
     return bottle.static_file(filepath, root=get_webpath('css'))
-  
+
 @route('/js/<filepath:path>')
 def js_pages(filepath):
     return bottle.static_file(filepath, root=get_webpath('js'))
@@ -162,7 +162,7 @@ def dateien():
       Msg.msg("WARN","Datei %s existiert nicht" % dateiname)
       deleted.append((dateiname,))
       continue
-      
+
     item = {}
     item['DATEI']       = os.path.basename(dateiname)
     item['DATUMFILM']   = row['DATUMFILM'].strftime("%d.%m.%y")


### PR DESCRIPTION
Beim Einrichten von mtv_cli konnte die Filmliste nicht aktualisiert werden. Dies führte dazu, dass eine Fehlerbehandlung versucht hat, das nicht initialisierte `fpin` zu schließen.