### PR TITLE
Ändere Downloadlink

### DIFF
--- a/files/usr/local/bin/mtv_const.py
+++ b/files/usr/local/bin/mtv_const.py
@@ -33,7 +33,4 @@ MTV_CLI_SQLITE=os.path.join(MTV_CLI_HOME,"mtv_cli.sqlite")
 
 # --- Download-URLs   --------------------------------------------------------
 
-URL_FILMLISTE=[
-  "https://verteiler1.mediathekview.de/Filmliste-akt.xz"
-  ]
-
+URL_FILMLISTE=["https://liste.mediathekview.de/Filmliste-akt.xz"]


### PR DESCRIPTION
In [1] wird beschrieben, dass MediathekView seine Download-URLs
umstrukturiert hat. Dieser Commit passt die eine verbliebene URL dem an.

  [1]: https://forum.mediathekview.de/topic/3508/aktuelle-verteiler-und-filmlisten-server

Schließt #6 .